### PR TITLE
fix slow overlay - fbo allocated every frame

### DIFF
--- a/src/ofxOculusDK2.cpp
+++ b/src/ofxOculusDK2.cpp
@@ -447,7 +447,7 @@ void ofxOculusDK2::beginOverlay(float overlayZ, float width, float height){
 	bUseOverlay = true;
 	overlayZDistance = overlayZ;
 	
-	if(overlayTarget.getWidth() != width || overlayTarget.getHeight() != height){
+	if((int)overlayTarget.getWidth() != (int)width || (int)overlayTarget.getHeight() != (int)height){
 		overlayTarget.allocate(width, height, GL_RGBA, 4);
 	}
 	


### PR DESCRIPTION
width/height float comparison was triggering condition every frame, causing the FBO to be allocated continuously and seriously affecting frame rate. Might not happen in all platforms, but its safer this way.